### PR TITLE
Dependency update and change to object-detection-0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 comtypes==1.1.7
-object-detection==0.1
-PyQt5==5.14.1
-PyQt5-sip==12.7.1
+object-detection-0.1==0.1
+PyQt5==5.14.2
+PyQt5-sip==12.7.2
 pywin32==227
 pywinauto==0.6.8
 six==1.14.0


### PR DESCRIPTION
Greetings I've tested but the following changes from your repo python 3.8.2 32-bit.

- General dependency update
`PyQt5==5.14.1` -> `PyQt5==5.14.2`
`PyQt5-sip==12.7.1` -> `PyQt5-sip==12.7.2`

- Dependency substitute
`object-detection==0.1`-> `object-detection-0.1==0.1`
`object-detection` requires Python 64-bit (downstream dependencies) where as `object-detection-0.1` does not.